### PR TITLE
Fix Relative Path Ref With No 'file' In URI

### DIFF
--- a/src/schema.jl
+++ b/src/schema.jl
@@ -49,7 +49,7 @@ function updateid(id0::HTTP.URI, s::String)
   if id2.path != ""  # replace path of id0
     oldpath = match(r"^(.*/).*$", id0.path)
     if oldpath == nothing
-      els[:path] = "/" * id2.path
+      els[:path] = id2.path
     else
       els[:path] = oldpath.captures[1] * id2.path
     end
@@ -117,7 +117,7 @@ function findref(id0, idmap, path::String, parentFileDirectory::String)
   # path is a URI
   uri = updateid(id0, path) # fullRefURI(HTTP.URI(path), id0)
   uri2 = rmfragment(uri) # without JPointer
-  
+
   isFileUri = startswith(uri2.scheme, "file") || isempty(uri2.scheme)
   # normalize a file path to an absolute path so creating a key is consistent
   if isFileUri

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -61,7 +61,7 @@ function writeLocalReferenceTestFiles()
             "type": "object",
             "properties": {
                 "result1": { "\$ref": "file:../$(basename(abspath(referenceComponentsDirectory)))/localReferenceSchemaOne.json#/properties/localRefOneResult" },
-                "result2": { "\$ref": "file:../$(basename(abspath(referenceComponentsDirectory)))/localReferenceSchemaTwo.json#/properties/localRefTwoResult" }
+                "result2": { "\$ref": "../$(basename(abspath(referenceComponentsDirectory)))/localReferenceSchemaTwo.json#/properties/localRefTwoResult" }
             },
             "oneOf": [
                 {


### PR DESCRIPTION
This fix is attempting to allow a relative reference to be specified without having to put 'file:..." in the designation.

* Do not prepend / to relative path when updating id
* Update relative ref test to use both 'file:../some/path' and '../some/path'
* All tests passed with change

It was not clear to me when the prepended '/' is needed so this change may be introducing a different bug.