### PR TITLE
Added the default parameter value for `parentFileDirectory`

### DIFF
--- a/src/schema.jl
+++ b/src/schema.jl
@@ -202,7 +202,7 @@ struct Schema
     new(spec0)
   end
 
-  function Schema(sp::String; idmap0=Dict{String, Any}(), parentFileDirectory::String)
+  function Schema(sp::String; idmap0=Dict{String, Any}(), parentFileDirectory::String = abspath("."))
     Schema(JSON.parse(sp), idmap0=idmap0, parentFileDirectory=parentFileDirectory)
   end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -178,3 +178,21 @@ end
     @test JSONSchema.is_json_integer(true) == false
     @test JSONSchema.is_json_integer(:a) == false
 end
+
+@testset "Schemas" begin
+    schema = Schema("""
+    {
+        \"properties\": {
+        \"foo\": {},
+        \"bar\": {}
+        },
+        \"required\": [\"foo\"]
+    }
+    """)
+    @test typeof(schema) == Schema
+    @test typeof(schema.data) == Dict{String,Any}
+
+    schema_2 = Schema(false)
+    @test typeof(schema_2) == Schema
+    @test typeof(schema_2.data) == Bool
+end


### PR DESCRIPTION
I believe the default value for the `parentFileDirectory` parameter was missing for one of the inner `Schema` type constructor functions. This should fix it.