### PR TITLE
Fixes for Julia 1.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.jl.cov
 *.jl.*.cov
 *.jl.mem
+Manifest.toml

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,40 +1,15 @@
 ## Documentation: http://docs.travis-ci.com/user/languages/julia/
 language: julia
-
+codecov: true
 os:
   - linux
   - osx
-
 julia:
-  - 0.7
   - 1.0
-  - nightly
-
+  - 1.1
+  - 1.2
+  - 1.3
 notifications:
   email: false
-
 git:
   depth: 99999999
-
-## uncomment the following lines to allow failures on nightly julia
-## (tests will run but not make your overall status red)
-matrix:
-  allow_failures:
-    - julia: nightly
-
-## uncomment and modify the following lines to manually install system packages
-#addons:
-#  apt: # apt-get for linux
-#    packages:
-#    - gfortran
-#before_script: # homebrew for mac
-#  - if [ $TRAVIS_OS_NAME = osx ]; then brew install gcc; fi
-
-## uncomment the following lines to override the default test script
-#script:
-#  - julia -e 'Pkg.clone(pwd()); Pkg.build("JSONSchema"); Pkg.test("JSONSchema"; coverage=true)'
-after_success:
-  # push coverage results to Coveralls
-  - julia -e 'cd(Pkg.dir("JSONSchema")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())'
-  # push coverage results to Codecov
-  - julia -e 'cd(Pkg.dir("JSONSchema")); Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())'

--- a/Project.toml
+++ b/Project.toml
@@ -1,0 +1,21 @@
+name = "JSONSchema"
+uuid = "7d188eb4-7ad8-530c-ae41-71a32a6d4692"
+verion = "0.2.0"
+
+[deps]
+BinaryProvider = "b99e7846-7c00-51b0-8f62-c81ae34c0232"
+HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
+JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+
+[compat]
+BinaryProvider = "0.5"
+HTTP = "0.8"
+JSON = "0.21"
+julia = "1"
+
+[extras]
+BinaryProvider = "b99e7846-7c00-51b0-8f62-c81ae34c0232"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Test", "BinaryProvider"]

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,0 @@
-julia 0.7
-JSON
-HTTP

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,26 +1,21 @@
 environment:
   matrix:
-  - julia_version: 0.7
   - julia_version: 1.0
-  - julia_version: nightly
+  - julia_version: 1.3
 
 platform:
   - x86 # 32-bit
   - x64 # 64-bit
 
-matrix:
-  allow_failures:
-  - julia_version: nightly
+# This is left as an example for the next big version switch.
+#matrix:
+#  allow_failures:
+#  - julia_version: latest
 
 branches:
   only:
     - master
     - /release-.*/
-
-matrix:
- allow_failures:
- - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"
- - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
 
 notifications:
   - provider: Email

--- a/src/JSONSchema.jl
+++ b/src/JSONSchema.jl
@@ -1,6 +1,5 @@
 module JSONSchema
 
-# using Compat
 using JSON
 import HTTP
 
@@ -11,4 +10,4 @@ export Schema, isvalid, diagnose
 include("schema.jl")
 include("validation.jl")
 
-end # module
+end

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,2 +1,0 @@
-BinaryProvider
-Test

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,10 +1,9 @@
-using JSONSchema, JSON
 import BinaryProvider
-
+using JSONSchema
+using JSON
 using Test
 
-### load the "json-schema-org/JSON-Schema-Test-Suite" project from github
-tsurl = "https://github.com/json-schema-org/JSON-Schema-Test-Suite/archive/master.tar.gz"
+tsurl = "https://github.com/json-schema-org/JSON-Schema-Test-Suite/archive/2.0.0.tar.gz"
 
 destdir = mktempdir()
 dwnldfn = joinpath(destdir, "test-suite.tar.gz")
@@ -13,14 +12,14 @@ BinaryProvider.download(tsurl, dwnldfn, verbose=true)
 unzipdir = joinpath(destdir, "test-suite")
 BinaryProvider.unpack(dwnldfn, unzipdir)
 
-jsonTestFilesDirectory = joinpath(unzipdir, "JSON-Schema-Test-Suite-master", "tests")
+jsonTestFilesDirectory = joinpath(unzipdir, "JSON-Schema-Test-Suite-2.0.0", "tests")
 localReferenceTestsDirectory = mktempdir(jsonTestFilesDirectory)
-
 
 """
 Write test files for locally referenced schema files.
-These files have the same format as JSON Schema org test files. They are written 
-to a sibling directory to JSON-Schema-Test-Suite-master/tests/draft* directories 
+
+    These files have the same format as JSON Schema org test files. They are written
+to a sibling directory to JSON-Schema-Test-Suite-master/tests/draft* directories
 so they can be consumed the same way as the draft*/*.json test files.
 """
 function writeLocalReferenceTestFiles()
@@ -35,7 +34,7 @@ function writeLocalReferenceTestFiles()
         }
     }
     """)
-    
+
     write(joinpath(referenceComponentsDirectory, "localReferenceSchemaTwo.json"), """
     {
         "type": "object",
@@ -44,7 +43,7 @@ function writeLocalReferenceTestFiles()
         }
     }
     """)
-    
+
     write(joinpath(referenceComponentsDirectory, "nestedLocalReference.json"), """
     {
         "type": "object",
@@ -53,7 +52,7 @@ function writeLocalReferenceTestFiles()
         }
     }
     """)
-    
+
     write(joinpath(localReferenceTestsDirectory, "localReferenceTest.json"), """[
     {
         "description": "test locally referenced schemas",
@@ -101,7 +100,7 @@ function writeLocalReferenceTestFiles()
         ]
     }
     ]""")
-    
+
     write(joinpath(localReferenceTestsDirectory, "nestedLocalReferenceTest.json"), """[
     {
         "description": "test locally referenced schemas",
@@ -126,7 +125,7 @@ function writeLocalReferenceTestFiles()
     }
     ]""")
     # return directory name (not path) of tests for use in testing below
-    return 
+    return
 end
 
 
@@ -155,12 +154,12 @@ writeLocalReferenceTestFiles()
 
         @testset "$tfn" for tfn in filter(n -> occursin(r"\.json$",n), readdir(tsdir))
             fn = joinpath(tsdir, tfn)
-            schema = JSON.parsefile(fn)            
+            schema = JSON.parsefile(fn)
             @testset "- $(subschema["description"])" for subschema in (schema)
-                spec = subschema["schema"] isa Bool ? 
-                    Schema(subschema["schema"]; idmap0=idmap0) : 
+                spec = subschema["schema"] isa Bool ?
+                    Schema(subschema["schema"]; idmap0=idmap0) :
                     Schema(subschema["schema"]; idmap0=idmap0, parentFileDirectory = dirname(fn))
-                    
+
                 @testset "* $(subtest["description"])" for subtest in subschema["tests"]
                     @test isvalid(subtest["data"], spec) == subtest["valid"]
                 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -166,5 +166,15 @@ writeLocalReferenceTestFiles()
             end
         end
     end
+end
 
+@testset "is_json_xxx" begin
+    @test JSONSchema.is_json_number(1) == true
+    @test JSONSchema.is_json_number(1.0) == true
+    @test JSONSchema.is_json_number(true) == false
+    @test JSONSchema.is_json_number(:a) == false
+    @test JSONSchema.is_json_integer(1) == true
+    @test JSONSchema.is_json_integer(1.0) == false
+    @test JSONSchema.is_json_integer(true) == false
+    @test JSONSchema.is_json_integer(:a) == false
 end


### PR DESCRIPTION
I ran into some 32-bit Windows failures while working on https://github.com/JuliaOpt/MathOptInterface.jl/pull/969. 

Here's the Appveyor log:
https://ci.appveyor.com/project/JuliaOpt/mathoptinterface-jl/builds/29419127/job/kruunajq0kw66gk1

I'm going to spend some time tidying up this package. 

This PR:

 - Adds a Project.toml
 - Simplifies the travis and appveyor submission scripts
 - Switches the tests from the master branch of the test-suite to a tag because they're working on a new draft
