### PR TITLE
[breaking] Re-write validation.jl

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "JSONSchema"
 uuid = "7d188eb4-7ad8-530c-ae41-71a32a6d4692"
-version = "0.2.0"
+version = "0.3.0"
 
 [deps]
 BinaryProvider = "b99e7846-7c00-51b0-8f62-c81ae34c0232"

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ julia> my_schema = Schema("""{
 ```
 passing a dictionary with the same structure as a schema:
 ```julia
-julia> schema = Schema(
+julia> my_schema = Schema(
             Dict(
                 "properties" => Dict(
                     "foo" => Dict(),
@@ -47,20 +47,23 @@ julia> my_schema = Schema(filename)
 ```
 
 Check the validity of a given JSON instance by calling
-`validate` with the JSON instance `x` to be tested and the `schema`:
+`validate` with the JSON instance `x` to be tested and the `schema`. If the validation succeeds, `validate` returns `nothing`:
 ```julia
 julia> data_pass = Dict("foo" => true)
 Dict{String,Bool} with 1 entry:
-    "foo" => true
+  "foo" => true
 
+julia> validate(data_pass, my_schema)
+
+```
+
+If the validation fails, a struct is returned that, when printed, explains the reason for the failure:
+```julia
 julia> data_fail = Dict("bar" => 12.5)
 Dict{String,Float64} with 1 entry:
-    "bar" => 12.5
+  "bar" => 12.5
 
-julia> validate(data_pass, my_schema; diagnose = true)
-Validation succeeded
-
-julia> validate(data_fail, my_schema; diagnose = true)
+julia> validate(data_fail, my_schema)
 Validation failed:
 path:         top-level
 instance:     Dict("bar"=>12.5)
@@ -68,9 +71,4 @@ schema key:   required
 schema value: ["foo"]
 ```
 
-If the validatation is successful, `validate` returns `nothing`.
-
-Passing `diagnose = false` will suppress printing.
-
-As a short-hand for `validate(x, schema; diagnose = false) === nothing`,
-you can use `Base.isvalid(x, schema)`.
+As a short-hand for `validate(x, schema) === nothing`, use `Base.isvalid(x, schema)`.

--- a/README.md
+++ b/README.md
@@ -9,46 +9,68 @@ _JSON instance validation using JSON Schemas_
 
 ## Overview
 
-[JSONSchema.jl](https://github.com/fredo-dedup/JSONSchema.jl) is a JSON validation package for the [julia](https://julialang.org/) programming language. Given a validation Schema (see http://json-schema.org/specification.html) this package can verify if any JSON instance follows all the assertions defining a valid document.
+[JSONSchema.jl](https://github.com/fredo-dedup/JSONSchema.jl) is a JSON validation package
+for the [julia](https://julialang.org/) programming language. Given a [validation
+schema](http://json-schema.org/specification.html) this package can verify if any JSON
+instance meets all the assertions defining a valid document.
 
-This package has been validated with the test suite of the JSON Schema org (https://github.com/json-schema-org/JSON-Schema-Test-Suite) for draft v4 and v6.
-
+This package has been validated with the [JSON Schema Test Suite](https://github.com/json-schema-org/JSON-Schema-Test-Suite)
+for draft v4 and v6.
 
 ## API
 
-First step is to create a `Schema` object :
+Create a `Schema` object by passing a string:
 ```julia
-# using a String as input
-myschema = Schema("""
- {
-    "properties": {
-       "foo": {},
-       "bar": {}
-    },
-    "required": ["foo"]
- }""")  
-
-# or using a pre-processed JSON as input, using the JSON package
-sch = JSON.parsefile(filepath)
-myschema = Schema(sch)
+julia> my_schema = Schema("""{
+            "properties": {
+                "foo": {},
+                "bar": {}
+            },
+            "required": ["foo"]
+        }""")
+```
+passing a dictionary with the same structure as a schema:
+```julia
+julia> schema = Schema(
+            Dict(
+                "properties" => Dict(
+                    "foo" => Dict(),
+                    "bar" => Dict()
+                ),
+                "required" => ["foo"]
+            )
+        )
+```
+or by passing a filename to a JSON file containing the schema:
+```julia
+julia> my_schema = Schema(filename)
 ```
 
-You can then check the validity of a given JSON instance by calling `isvalid`
-with the JSON instance to be tested and the `Schema`:
+Check the validity of a given JSON instance by calling
+`validate` with the JSON instance `x` to be tested and the `schema`:
 ```julia
-isvalid( JSON.parse("{ "foo": true }"), myschema) # true
-isvalid( JSON.parse("{ "bar": 12.5 }"), myschema) # false
-```
-The JSON instance should be provided as a pre-processed `JSON` object created
-with the `JSON` package.
+julia> data_pass = Dict("foo" => true)
+Dict{String,Bool} with 1 entry:
+    "foo" => true
 
+julia> data_fail = Dict("bar" => 12.5)
+Dict{String,Float64} with 1 entry:
+    "bar" => 12.5
 
-Should you need a diagnostic message to understand the cause of rejection you
-can use the `diagnose()` function. `diagnose()` will either return `nothing`
-if the instance is valid or a message detailing which assertion failed.
-```julia
-diagnose( JSON.parse("{ "foo": true }") , myschema)
-# nothing
-diagnose( JSON.parse("{ "bar": 12.5 }") , myschema)
-# "in [] : required property 'foo' missing"
+julia> validate(data_pass, my_schema; diagnose = true)
+Validation succeeded
+
+julia> validate(data_fail, my_schema; diagnose = true)
+Validation failed:
+path:         top-level
+instance:     Dict("bar"=>12.5)
+schema key:   required
+schema value: ["foo"]
 ```
+
+If the validatation is successful, `validate` returns `nothing`.
+
+Passing `diagnose = false` will suppress printing.
+
+As a short-hand for `validate(x, schema; diagnose = false) === nothing`,
+you can use `Base.isvalid(x, schema)`.

--- a/README.md
+++ b/README.md
@@ -41,13 +41,13 @@ julia> my_schema = Schema(
             )
         )
 ```
-or by passing a filename to a JSON file containing the schema:
+or by passing a parsed JSON file containing the schema:
 ```julia
-julia> my_schema = Schema(filename)
+julia> my_schema = Schema(JSON.parsefile(filename))
 ```
 
-Check the validity of a given JSON instance by calling
-`validate` with the JSON instance `x` to be tested and the `schema`. If the validation succeeds, `validate` returns `nothing`:
+Check the validity of a given JSON instance by calling `validate` with the JSON instance `x`
+to be tested and the `schema`. If the validation succeeds, `validate` returns `nothing`:
 ```julia
 julia> data_pass = Dict("foo" => true)
 Dict{String,Bool} with 1 entry:
@@ -57,7 +57,8 @@ julia> validate(data_pass, my_schema)
 
 ```
 
-If the validation fails, a struct is returned that, when printed, explains the reason for the failure:
+If the validation fails, a struct is returned that, when printed, explains the reason for
+the failure:
 ```julia
 julia> data_fail = Dict("bar" => 12.5)
 Dict{String,Float64} with 1 entry:

--- a/src/JSONSchema.jl
+++ b/src/JSONSchema.jl
@@ -3,13 +3,12 @@ module JSONSchema
 using JSON
 import HTTP
 
-import Base: isvalid
-
-export Schema, isvalid, diagnose
+export Schema, validate
 
 include("schema.jl")
 include("validation.jl")
 
+export diagnose
 function diagnose(x, schema)
     Base.depwarn(
         "`diagnose(x, schema)` is deprecated. Use `validate(x, schema; diagnose=true)` " *

--- a/src/JSONSchema.jl
+++ b/src/JSONSchema.jl
@@ -10,4 +10,14 @@ export Schema, isvalid, diagnose
 include("schema.jl")
 include("validation.jl")
 
+function diagnose(x, schema)
+    Base.depwarn(
+        "`diagnose(x, schema)` is deprecated. Use `validate(x, schema; diagnose=true)` " *
+        "instead.",
+        :diagnose
+    )
+    validate(x, schema; diagnose = true)
+    return
+end
+
 end

--- a/src/JSONSchema.jl
+++ b/src/JSONSchema.jl
@@ -11,11 +11,10 @@ include("validation.jl")
 export diagnose
 function diagnose(x, schema)
     Base.depwarn(
-        "`diagnose(x, schema)` is deprecated. Use `validate(x, schema)` " *
-        "instead.",
+        "`diagnose(x, schema)` is deprecated. Use `validate(x, schema)` instead.",
         :diagnose
     )
-    ret = validate(x, schema; diagnose = false)
+    ret = validate(x, schema)
     return ret === nothing ? nothing : sprint(show, ret)
 end
 

--- a/src/JSONSchema.jl
+++ b/src/JSONSchema.jl
@@ -11,12 +11,12 @@ include("validation.jl")
 export diagnose
 function diagnose(x, schema)
     Base.depwarn(
-        "`diagnose(x, schema)` is deprecated. Use `validate(x, schema; diagnose=true)` " *
+        "`diagnose(x, schema)` is deprecated. Use `validate(x, schema)` " *
         "instead.",
         :diagnose
     )
-    validate(x, schema; diagnose = true)
-    return
+    ret = validate(x, schema; diagnose = false)
+    return ret === nothing ? nothing : sprint(show, ret)
 end
 
 end

--- a/src/validation.jl
+++ b/src/validation.jl
@@ -14,14 +14,16 @@ function Base.show(io::IO, issue::SingleIssue)
 end
 
 """
-    _validate(x, s::Schema; diagnose::Bool = false)
+    validate(x, s::Schema; diagnose::Bool = false)
 
 Validate document `x` is valid against the Schema `s`. If valid, return `nothing`, else
 return a `SingleIssue`.
 
-If `diagnose`, print a human-readable string saying why the validation failed.
+If `diagnose`, print a human-readable string saying why the validation failed, or if it
+succeeded.
 
 ## Examples
+
     julia> schema = Schema(
                Dict(
                    "properties" => Dict(
@@ -42,6 +44,7 @@ If `diagnose`, print a human-readable string saying why the validation failed.
       "bar" => 12.5
 
     julia> validate(data_pass, schema; diagnose = true)
+    Validation succeeded
 
     julia> validate(data_fail, schema; diagnose = true)
     Validation failed:

--- a/src/validation.jl
+++ b/src/validation.jl
@@ -14,13 +14,11 @@ function Base.show(io::IO, issue::SingleIssue)
 end
 
 """
-    validate(x, s::Schema; diagnose::Bool = false)
+    validate(x, s::Schema)
 
 Validate document `x` is valid against the Schema `s`. If valid, return `nothing`, else
-return a `SingleIssue`.
-
-If `diagnose`, print a human-readable string saying why the validation failed, or if it
-succeeded.
+return a `SingleIssue`. When printed, the returned `SingleIssue` describes the reason why
+the validation failed.
 
 ## Examples
 
@@ -43,25 +41,20 @@ succeeded.
     Dict{String,Float64} with 1 entry:
       "bar" => 12.5
 
-    julia> validate(data_pass, schema; diagnose = true)
-    Validation succeeded
+    julia> validate(data_pass, schema)
 
-    julia> validate(data_fail, schema; diagnose = true)
+    julia> validate(data_fail, schema)
     Validation failed:
     path:         top-level
     instance:     Dict("bar"=>12.5)
     schema key:   required
     schema value: ["foo"]
 """
-function validate(x, schema::Schema; diagnose::Bool = false)
-    ret = _validate(x, schema.data, "")
-    if diagnose
-        println(ret === nothing ? "Validation succeeded" : ret)
-    end
-    return ret
+function validate(x, schema::Schema)
+    return _validate(x, schema.data, "")
 end
 
-Base.isvalid(x, schema::Schema) = validate(x, schema; diagnose = false) === nothing
+Base.isvalid(x, schema::Schema) = validate(x, schema) === nothing
 
 function _validate(x, schema, path::String)
     schema = _resolve_refs(schema)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -187,13 +187,15 @@ end
     @test JSONSchema.validate(data_pass, schema; diagnose = true) === nothing
     ret = JSONSchema.validate(data_fail, schema; diagnose = true)
     @test ret !== nothing
-    @test sprint(show, ret) == """Validation failed:
+    fail_msg = """Validation failed:
     path:         top-level
     instance:     $(data_fail)
     schema key:   required
     schema value: ["foo"]
     """
-    @test diagnose(data_fail, schema) === nothing
+    @test sprint(show, ret) == fail_msg
+    @test diagnose(data_pass, schema) === nothing
+    @test diagnose(data_fail, schema) == fail_msg
 end
 
 @testset "Schemas" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -172,7 +172,7 @@ writeLocalReferenceTestFiles()
     end
 end
 
-@testset "" begin
+@testset "Validate and diagnose" begin
     schema = Schema(
         Dict(
             "properties" => Dict(
@@ -184,15 +184,15 @@ end
     )
     data_pass = Dict("foo" => true)
     data_fail = Dict("bar" => 12.5)
-    @test JSONSchema.validate(data_pass, schema; diagnose = true) === nothing
-    ret = JSONSchema.validate(data_fail, schema; diagnose = true)
-    @test ret !== nothing
+    @test JSONSchema.validate(data_pass, schema) === nothing
+    ret = JSONSchema.validate(data_fail, schema)
     fail_msg = """Validation failed:
     path:         top-level
     instance:     $(data_fail)
     schema key:   required
     schema value: ["foo"]
     """
+    @test ret !== nothing
     @test sprint(show, ret) == fail_msg
     @test diagnose(data_pass, schema) === nothing
     @test diagnose(data_fail, schema) == fail_msg

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -161,22 +161,39 @@ writeLocalReferenceTestFiles()
                     Schema(subschema["schema"]; idmap0=idmap0, parentFileDirectory = dirname(fn))
 
                 @testset "* $(subtest["description"])" for subtest in subschema["tests"]
-                    @test isvalid(subtest["data"], spec) == subtest["valid"]
+                    result = isvalid(subtest["data"], spec) == subtest["valid"]
+                    @test result
+                    if !result
+                        @show subtest, spec.data
+                    end
                 end
             end
         end
     end
 end
 
-@testset "is_json_xxx" begin
-    @test JSONSchema.is_json_number(1) == true
-    @test JSONSchema.is_json_number(1.0) == true
-    @test JSONSchema.is_json_number(true) == false
-    @test JSONSchema.is_json_number(:a) == false
-    @test JSONSchema.is_json_integer(1) == true
-    @test JSONSchema.is_json_integer(1.0) == false
-    @test JSONSchema.is_json_integer(true) == false
-    @test JSONSchema.is_json_integer(:a) == false
+@testset "" begin
+    schema = Schema(
+        Dict(
+            "properties" => Dict(
+                "foo" => Dict(),
+                "bar" => Dict()
+            ),
+            "required" => ["foo"]
+        )
+    )
+    data_pass = Dict("foo" => true)
+    data_fail = Dict("bar" => 12.5)
+    @test JSONSchema.validate(data_pass, schema; diagnose = true) === nothing
+    ret = JSONSchema.validate(data_fail, schema; diagnose = true)
+    @test ret !== nothing
+    @test sprint(show, ret) == """Validation failed:
+    path:         top-level
+    instance:     $(data_fail)
+    schema key:   required
+    schema value: ["foo"]
+    """
+    @test diagnose(data_fail, schema) === nothing
 end
 
 @testset "Schemas" begin


### PR DESCRIPTION
<s>@fredo-dedup if you're okay with it, I'm in favor of removing the macro usage within this package. 

The downside is a few more lines of code, but (in my opinion) it makes the code more readable for newcomers (e.g., me).

In a separate PR, I'll get rid of `@doassert`. Then we can refactor some of the methods. Following #6, it'd be nice if there was an easy way of declaring schema rules.</s>

This PR is a re-write of the `src/validation.jl` file. It removes the macros and is more modular. 

Section numbers come from the [2019-09 schema](https://json-schema.org/draft/2019-09/json-schema-validation.html).

Decisions:
- [x] I've currently removed (but deprecated) `diagnose` in favor of `validate(x, schema)`
- [x] This package shouldn't export `isvalid`. It currently has `import Base: isvalid` and `export isvalid`, so we can just remove both these lines without breaking code (I think).