### PR TITLE
Updates to schema.jl and runtests.jl

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,19 +3,18 @@ uuid = "7d188eb4-7ad8-530c-ae41-71a32a6d4692"
 version = "0.3.0"
 
 [deps]
-BinaryProvider = "b99e7846-7c00-51b0-8f62-c81ae34c0232"
 HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+ZipFile = "a5390f91-8eb1-5f08-bee0-b1d1ffed6cea"
 
 [compat]
-BinaryProvider = "0.5"
 HTTP = "0.8"
 JSON = "0.21"
+ZipFile = "~0.8"
 julia = "1"
 
 [extras]
-BinaryProvider = "b99e7846-7c00-51b0-8f62-c81ae34c0232"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "BinaryProvider"]
+test = ["Test"]

--- a/Project.toml
+++ b/Project.toml
@@ -10,7 +10,7 @@ ZipFile = "a5390f91-8eb1-5f08-bee0-b1d1ffed6cea"
 [compat]
 HTTP = "0.8"
 JSON = "0.21"
-ZipFile = "~0.8"
+ZipFile = "0.8, 0.9"
 julia = "1"
 
 [extras]

--- a/src/schema.jl
+++ b/src/schema.jl
@@ -70,7 +70,7 @@ function get_remote_schema(uri::HTTP.URI)
     return Schema(JSON.parse(String(r.body)))
 end
 
-function find_ref(id0, idmap, path::String, parentFileDirectory::String)
+function find_ref(id0, idmap, path::String, dir::String)
     if path == "" || path == "#"  # This path refers to the root schema.
         return idmap[string(id0)]
     elseif startswith(path, "#/")  # This path is a JPointer.
@@ -85,7 +85,7 @@ function find_ref(id0, idmap, path::String, parentFileDirectory::String)
     if isFileUri && !isabspath(uri2.path)
         uri2 = HTTP.URIs.merge(
             uri2;
-            path = abspath(joinpath(parentFileDirectory, uri2.path))
+            path = abspath(joinpath(dir, uri2.path))
         )
     end
     if !haskey(idmap, string(uri2))  # if not referenced already, fetch remote ref, add to idmap
@@ -96,7 +96,7 @@ function find_ref(id0, idmap, path::String, parentFileDirectory::String)
             @info("loading local ref $(uri2)")
             idmap[string(uri2)] = Schema(
                 JSON.parsefile(uri2.path);
-                parentFileDirectory = dirname(uri2.path)
+                dir = dirname(uri2.path)
             ).data
         end
     end
@@ -110,10 +110,10 @@ function resolve_refs!(
     schema::Vector,
     uri::HTTP.URI,
     id_map::Dict{String,Any},
-    parentFileDirectory::String
+    dir::String
 )
     for s in schema
-        resolve_refs!(s, uri, id_map, parentFileDirectory)
+        resolve_refs!(s, uri, id_map, dir)
     end
     return
 end
@@ -122,7 +122,7 @@ function resolve_refs!(
     schema::Dict,
     uri::HTTP.URI,
     id_map::Dict{String,Any},
-    parentFileDirectory::String
+    dir::String
 )
     if haskey(schema, "id") && schema["id"] isa String
         # This block is for draft 4.
@@ -138,9 +138,9 @@ function resolve_refs!(
             # We will replace the path string with the schema element pointed at, thus
             # marking it as resolved. This should prevent infinite recursions caused by
             # self referencing.
-            schema["\$ref"] = find_ref(uri, id_map, v, parentFileDirectory)
+            schema["\$ref"] = find_ref(uri, id_map, v, dir)
         else
-            resolve_refs!(v, uri, id_map, parentFileDirectory)
+            resolve_refs!(v, uri, id_map, dir)
         end
     end
     return
@@ -178,12 +178,48 @@ function build_id_map!(id_map::Dict{String,Any}, schema::Dict, uri::HTTP.URI)
 end
 
 """
-    Schema(schema::String)
 
-Create a schema for document validation. `schema` should be a String containing a
-valid JSON.
+    Schema(schema::Dict; dir::String = abspath("."))
 
-## Example
+Create a schema but with `schema` being a parsed JSON created with `JSON.parse()` or
+`JSON.parsefile()`.
+
+`dir` is the path with respect to which references to local schemas are resolved.
+
+## Examples
+
+    my_schema = Schema(JSON.parsefile(filename))
+    my_schema = Schema(JSON.parsefile(filename); dir = "~/schemas")
+"""
+struct Schema
+    data::Union{Dict{String, Any}, Bool}
+
+    Schema(schema::Bool; kwargs...) = new(schema)
+
+    function Schema(
+        schema::Dict;
+        dir::String = abspath("."),
+        parentFileDirectory = nothing,
+    )
+        if parentFileDirectory !== nothing
+            @warn("kwarg `parentFileDirectory` is deprecated. Use `dir` instead.")
+            dir = parentFileDirectory
+        end
+        schema = deepcopy(schema)  # Ensure we don't modify the user's data!
+        id_map = build_id_map(schema)
+        resolve_refs!(schema, HTTP.URI(), id_map, dir)
+        return new(schema)
+    end
+end
+
+"""
+    Schema(schema::String; dir::String = abspath("."))
+
+Create a schema for document validation by parsing the string `schema`.
+
+`dir` is the path with respect to which references to local schemas are resolved.
+
+## Examples
 
     my_schema = Schema(\"\"\"{
         \"properties\": {
@@ -193,31 +229,14 @@ valid JSON.
         \"required\": [\"foo\"]
     }\"\"\")
 
-    Schema(schema::Dict)
-
-Create a schema but with `schema` being a parsed JSON created with `JSON.parse()` or
-`JSON.parsefile()`.
-
-## Example
-
-    julia> my_schema = Schema(JSON.parsefile(filename))
-"""
-struct Schema
-    data::Union{Dict{String, Any}, Bool}
-
-    Schema(schema::Bool; kwargs...) = new(schema)
-
-    function Schema(
-        schema::Dict;
-        parentFileDirectory::String = abspath("."),
+    # Assume there exists `~/schemas/local_file.json`:
+    my_schema = Schema(
+        \"\"\"{
+            "\$ref": "local_file.json"
+        }\"\"\",
+        dir = "~/schemas"
     )
-        schema = deepcopy(schema)  # Ensure we don't modify the user's data!
-        id_map = build_id_map(schema)
-        resolve_refs!(schema, HTTP.URI(), id_map, parentFileDirectory)
-        return new(schema)
-    end
-end
-
+"""
 Schema(schema::String; kwargs...) = Schema(JSON.parse(schema); kwargs...)
 
 Base.show(io::IO, ::Schema) = print(io, "A JSONSchema")

--- a/src/schema.jl
+++ b/src/schema.jl
@@ -47,7 +47,7 @@ end
 
 function _recurse_get_element(schema::Dict, element::String)
     if !haskey(schema, element)
-        error("missing property '$(element)' in $(schema)")
+        error("missing property '$(element)' in $(schema).")
     end
     return schema[element]
 end
@@ -55,9 +55,9 @@ end
 function _recurse_get_element(schema::Vector, element::String)
     index = tryparse(Int, element)  # Remember that `index` is 0-indexed!
     if index === nothing
-        error("expected integer array index instead of '$(element)'")
+        error("expected integer array index instead of '$(element)'.")
     elseif index >= length(schema)
-        error("item index $(index) is larger than array $(schema)")
+        error("item index $(index) is larger than array $(schema).")
     end
     return schema[index + 1]
 end
@@ -220,4 +220,4 @@ end
 
 Schema(schema::String; kwargs...) = Schema(JSON.parse(schema); kwargs...)
 
-Base.show(io::IO, ::Schema) = println(io, "A JSONSchema")
+Base.show(io::IO, ::Schema) = print(io, "A JSONSchema")

--- a/src/validation.jl
+++ b/src/validation.jl
@@ -81,7 +81,7 @@ function _resolve_refs(schema::Dict, explored_refs = Any[schema])
     end
     schema = schema["\$ref"]
     if schema in explored_refs
-        error("Cannot support circular references in schema.")
+        error("cannot support circular references in schema.")
     end
     push!(explored_refs, schema)
     return _resolve_refs(schema, explored_refs)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -29,18 +29,14 @@ write(
     joinpath(REF_LOCAL_TEST_DIR, "localReferenceSchemaOne.json"),
     """{
     "type": "object",
-    "properties": {
-        "localRefOneResult": { "type": "string" }
-    }
+    "properties": {"localRefOneResult": {"type": "string"}}
 }""")
 
 write(
     joinpath(REF_LOCAL_TEST_DIR, "localReferenceSchemaTwo.json"),
     """{
     "type": "object",
-    "properties": {
-        "localRefTwoResult": { "type": "number" }
-    }
+    "properties": {"localRefTwoResult": {"type": "number"}}
 }""")
 
 write(
@@ -48,7 +44,9 @@ write(
     """{
     "type": "object",
     "properties": {
-        "result": { "\$ref": "file:localReferenceSchemaOne.json#/properties/localRefOneResult" }
+        "result": {
+            "\$ref": "file:localReferenceSchemaOne.json#/properties/localRefOneResult"
+        }
     }
 }""")
 
@@ -62,42 +60,33 @@ write(
             "result1": { "\$ref": "file:../$(basename(abspath(REF_LOCAL_TEST_DIR)))/localReferenceSchemaOne.json#/properties/localRefOneResult" },
             "result2": { "\$ref": "../$(basename(abspath(REF_LOCAL_TEST_DIR)))/localReferenceSchemaTwo.json#/properties/localRefTwoResult" }
         },
-        "oneOf": [
-            {
-                "required": ["result1"]
-            },
-            {
-                "required": ["result2"]
-            }
-        ]
+        "oneOf": [{
+            "required": ["result1"]
+        }, {
+            "required": ["result2"]
+        }]
     },
-    "tests": [
-        {
-            "description": "reference only local schema 1",
-            "data": {"result1": "some text" },
-            "valid": true
-        },
-        {
-            "description": "reference only local schema 2",
-                "data": {"result2": 1234 },
-                "valid": true
-        },
-        {
-            "description": "incorrect reference to local schema 1",
-                "data": { "result1": true },
-                "valid": false
-        },
-        {
-            "description": "reference neither local schemas",
-                "data": { "result": true },
-                "valid": false
-        },
-        {
-            "description": "reference both local schemas",
-            "data": {"result1": "some text", "result2": 500 },
-            "valid": false
-        }
-    ]
+    "tests": [{
+        "description": "reference only local schema 1",
+        "data": {"result1": "some text"},
+        "valid": true
+    }, {
+        "description": "reference only local schema 2",
+        "data": {"result2": 1234},
+        "valid": true
+    }, {
+        "description": "incorrect reference to local schema 1",
+        "data": {"result1": true},
+        "valid": false
+    }, {
+        "description": "reference neither local schemas",
+        "data": {"result": true},
+        "valid": false
+    }, {
+        "description": "reference both local schemas",
+        "data": {"result1": "some text", "result2": 500},
+        "valid": false
+    }]
 }]""")
 
 write(
@@ -107,21 +96,20 @@ write(
     "schema": {
         "type": "object",
         "properties": {
-            "result": { "\$ref": "file:../$(basename(abspath(REF_LOCAL_TEST_DIR)))/nestedLocalReference.json#/properties/result" }
+            "result": {
+                "\$ref": "file:../$(basename(abspath(REF_LOCAL_TEST_DIR)))/nestedLocalReference.json#/properties/result"
+            }
         }
     },
-    "tests": [
-        {
-            "description": "nested reference, correct type",
-            "data": {"result": "some text" },
-            "valid": true
-        },
-        {
-            "description": "nested reference, incorrect type",
-            "data": {"result": 1234 },
-            "valid": false
-        }
-    ]
+    "tests": [{
+        "description": "nested reference, correct type",
+        "data": {"result": "some text"},
+        "valid": true
+    }, {
+        "description": "nested reference, incorrect type",
+        "data": {"result": 1234},
+        "valid": false
+    }]
 }]""")
 
 @testset "Draft 4/6" begin
@@ -147,13 +135,15 @@ write(
     ]
         test_dir = joinpath(SCHEMA_TEST_DIR, draft_folder)
         GLOBAL_TEST_DIR[] = test_dir
-        @testset "$tfn" for tfn in filter(n -> occursin(r"\.json$",n), readdir(test_dir))
-            fn = joinpath(test_dir, tfn)
-            @testset "- $(subschema["description"])" for subschema in (JSON.parsefile(fn))
-                dir = subschema["schema"] isa Bool ? abspath(".") : dirname(fn)
-                spec = Schema(subschema["schema"]; parentFileDirectory = dir)
-                @testset "* $(subtest["description"])" for subtest in subschema["tests"]
-                    @test isvalid(subtest["data"], spec) == subtest["valid"]
+        @testset "$(file)" for file in filter(n -> endswith(n, ".json"), readdir(test_dir))
+            file_path = joinpath(test_dir, file)
+            @testset "$(schema["description"])" for schema in JSON.parsefile(file_path)
+                spec = Schema(
+                    schema["schema"];
+                    dir = schema["schema"] isa Bool ? abspath(".") : dirname(file_path)
+                )
+                @testset "$(test["description"])" for test in schema["tests"]
+                    @test isvalid(test["data"], spec) == test["valid"]
                 end
             end
         end
@@ -162,15 +152,13 @@ write(
 end
 
 @testset "Validate and diagnose" begin
-    schema = Schema(
-        Dict(
-            "properties" => Dict(
-                "foo" => Dict(),
-                "bar" => Dict()
-            ),
-            "required" => ["foo"]
-        )
-    )
+    schema = Schema(Dict(
+        "properties" => Dict(
+            "foo" => Dict(),
+            "bar" => Dict()
+        ),
+        "required" => ["foo"]
+    ))
     data_pass = Dict("foo" => true)
     data_fail = Dict("bar" => 12.5)
     @test JSONSchema.validate(data_pass, schema) === nothing
@@ -188,15 +176,13 @@ end
 end
 
 @testset "Schemas" begin
-    schema = Schema("""
-    {
+    schema = Schema("""{
         \"properties\": {
         \"foo\": {},
         \"bar\": {}
         },
         \"required\": [\"foo\"]
-    }
-    """)
+    }""")
     @test typeof(schema) == Schema
     @test typeof(schema.data) == Dict{String,Any}
 
@@ -221,7 +207,7 @@ end
     )
 
     @test_throws(
-        ErrorException("unmanaged type in ref resolution $(Int): 1."),
+        ErrorException("unmanaged type in ref resolution $(Int64): 1."),
         Schema("""{
             "type": "object",
             "properties": {"version": {"\$ref": "#/definitions/Foo"}},

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,175 +1,164 @@
-import BinaryProvider
+using BinaryProvider
+using HTTP
 using JSONSchema
 using JSON
 using Test
 
-tsurl = "https://github.com/json-schema-org/JSON-Schema-Test-Suite/archive/2.0.0.tar.gz"
+const TEST_SUITE_URL = "https://github.com/json-schema-org/JSON-Schema-Test-Suite/archive/2.0.0.tar.gz"
 
-destdir = mktempdir()
-dwnldfn = joinpath(destdir, "test-suite.tar.gz")
-BinaryProvider.download(tsurl, dwnldfn, verbose=true)
-
-unzipdir = joinpath(destdir, "test-suite")
-BinaryProvider.unpack(dwnldfn, unzipdir)
-
-jsonTestFilesDirectory = joinpath(unzipdir, "JSON-Schema-Test-Suite-2.0.0", "tests")
-localReferenceTestsDirectory = mktempdir(jsonTestFilesDirectory)
-
-"""
-Write test files for locally referenced schema files.
-
-    These files have the same format as JSON Schema org test files. They are written
-to a sibling directory to JSON-Schema-Test-Suite-master/tests/draft* directories
-so they can be consumed the same way as the draft*/*.json test files.
-"""
-function writeLocalReferenceTestFiles()
-    # sibling directory for testing a relative path containing "../"
-    referenceComponentsDirectory = mktempdir(jsonTestFilesDirectory)
-
-    write(joinpath(referenceComponentsDirectory, "localReferenceSchemaOne.json"), """
-    {
-        "type": "object",
-        "properties": {
-            "localRefOneResult": { "type": "string" }
-        }
-    }
-    """)
-
-    write(joinpath(referenceComponentsDirectory, "localReferenceSchemaTwo.json"), """
-    {
-        "type": "object",
-        "properties": {
-            "localRefTwoResult": { "type": "number" }
-        }
-    }
-    """)
-
-    write(joinpath(referenceComponentsDirectory, "nestedLocalReference.json"), """
-    {
-        "type": "object",
-        "properties": {
-            "result": { "\$ref": "file:localReferenceSchemaOne.json#/properties/localRefOneResult" }
-        }
-    }
-    """)
-
-    write(joinpath(localReferenceTestsDirectory, "localReferenceTest.json"), """[
-    {
-        "description": "test locally referenced schemas",
-        "schema": {
-            "type": "object",
-            "properties": {
-                "result1": { "\$ref": "file:../$(basename(abspath(referenceComponentsDirectory)))/localReferenceSchemaOne.json#/properties/localRefOneResult" },
-                "result2": { "\$ref": "../$(basename(abspath(referenceComponentsDirectory)))/localReferenceSchemaTwo.json#/properties/localRefTwoResult" }
-            },
-            "oneOf": [
-                {
-                    "required": ["result1"]
-                },
-                {
-                    "required": ["result2"]
-                }
-            ]
-        },
-        "tests": [
-            {
-                "description": "reference only local schema 1",
-                "data": {"result1": "some text" },
-                "valid": true
-            },
-            {
-                "description": "reference only local schema 2",
-                    "data": {"result2": 1234 },
-                    "valid": true
-            },
-            {
-                "description": "incorrect reference to local schema 1",
-                    "data": { "result1": true },
-                    "valid": false
-            },
-            {
-                "description": "reference neither local schemas",
-                    "data": { "result": true },
-                    "valid": false
-            },
-            {
-                "description": "reference both local schemas",
-                "data": {"result1": "some text", "result2": 500 },
-                "valid": false
-            }
-        ]
-    }
-    ]""")
-
-    write(joinpath(localReferenceTestsDirectory, "nestedLocalReferenceTest.json"), """[
-    {
-        "description": "test locally referenced schemas",
-        "schema": {
-            "type": "object",
-            "properties": {
-                "result": { "\$ref": "file:../$(basename(abspath(referenceComponentsDirectory)))/nestedLocalReference.json#/properties/result" }
-            }
-        },
-        "tests": [
-            {
-                "description": "nested reference, correct type",
-                "data": {"result": "some text" },
-                "valid": true
-            },
-            {
-                "description": "nested reference, incorrect type",
-                "data": {"result": 1234 },
-                "valid": false
-            }
-        ]
-    }
-    ]""")
-    # return directory name (not path) of tests for use in testing below
-    return
+const SCHEMA_TEST_DIR = let
+    dest_dir = mktempdir()
+    dest_file = joinpath(dest_dir, "test-suite.tar.gz")
+    BinaryProvider.download(TEST_SUITE_URL, dest_file, verbose = true)
+    unzip_dir = joinpath(dest_dir, "test-suite")
+    BinaryProvider.unpack(dest_file, unzip_dir)
+    joinpath(unzip_dir, "JSON-Schema-Test-Suite-2.0.0", "tests")
 end
 
+const LOCAL_TEST_DIR = mktempdir(SCHEMA_TEST_DIR)
 
-writeLocalReferenceTestFiles()
+# Write test files for locally referenced schema files.
+#
+# These files have the same format as JSON Schema org test files. They are written
+# to a sibling directory to JSON-Schema-Test-Suite-master/tests/draft* directories
+# so they can be consumed the same way as the draft*/*.json test files.
+# sibling directory for testing a relative path containing "../"
+const REF_LOCAL_TEST_DIR = mktempdir(SCHEMA_TEST_DIR)
 
+write(
+    joinpath(REF_LOCAL_TEST_DIR, "localReferenceSchemaOne.json"),
+    """{
+    "type": "object",
+    "properties": {
+        "localRefOneResult": { "type": "string" }
+    }
+}""")
 
-@testset begin
+write(
+    joinpath(REF_LOCAL_TEST_DIR, "localReferenceSchemaTwo.json"),
+    """{
+    "type": "object",
+    "properties": {
+        "localRefTwoResult": { "type": "number" }
+    }
+}""")
 
-    ################################################################################
-    ### Applying test suites for draft 4/6 specifications, and local ref tests   ###
-    ################################################################################
+write(
+    joinpath(REF_LOCAL_TEST_DIR, "nestedLocalReference.json"),
+    """{
+    "type": "object",
+    "properties": {
+        "result": { "\$ref": "file:localReferenceSchemaOne.json#/properties/localRefOneResult" }
+    }
+}""")
 
-    # add custom directory containing tests for locally referenced schema files
-    localRefTestDirectoryName = basename(abspath(localReferenceTestsDirectory))
-    @testset "Test suite for $draftfn" for draftfn in ["draft4", "draft6", localRefTestDirectoryName]
-        tsdir = joinpath(jsonTestFilesDirectory, draftfn)
+write(
+    joinpath(LOCAL_TEST_DIR, "localReferenceTest.json"),
+    """[{
+    "description": "test locally referenced schemas",
+    "schema": {
+        "type": "object",
+        "properties": {
+            "result1": { "\$ref": "file:../$(basename(abspath(REF_LOCAL_TEST_DIR)))/localReferenceSchemaOne.json#/properties/localRefOneResult" },
+            "result2": { "\$ref": "../$(basename(abspath(REF_LOCAL_TEST_DIR)))/localReferenceSchemaTwo.json#/properties/localRefTwoResult" }
+        },
+        "oneOf": [
+            {
+                "required": ["result1"]
+            },
+            {
+                "required": ["result2"]
+            }
+        ]
+    },
+    "tests": [
+        {
+            "description": "reference only local schema 1",
+            "data": {"result1": "some text" },
+            "valid": true
+        },
+        {
+            "description": "reference only local schema 2",
+                "data": {"result2": 1234 },
+                "valid": true
+        },
+        {
+            "description": "incorrect reference to local schema 1",
+                "data": { "result1": true },
+                "valid": false
+        },
+        {
+            "description": "reference neither local schemas",
+                "data": { "result": true },
+                "valid": false
+        },
+        {
+            "description": "reference both local schemas",
+            "data": {"result1": "some text", "result2": 500 },
+            "valid": false
+        }
+    ]
+}]""")
 
-        # the test suites use the 'remotes' folder to simulate remote refs with the
-        #  'http://localhost:1234' url.  To have tests cope with this, the id dictionary
-        # is preloaded with the files in ''../remotes'
-        idmap0 = Dict{String, Any}()
-        remfn = joinpath(tsdir, "../../remotes")
-        for rn in ["integer.json", "name.json", "subSchemas.json", "folder/folderInteger.json"]
-            idmap0["http://localhost:1234/" * rn] = Schema(JSON.parsefile(joinpath(remfn, rn))).data
-        end
+write(
+    joinpath(LOCAL_TEST_DIR, "nestedLocalReferenceTest.json"),
+    """[{
+    "description": "test locally referenced schemas",
+    "schema": {
+        "type": "object",
+        "properties": {
+            "result": { "\$ref": "file:../$(basename(abspath(REF_LOCAL_TEST_DIR)))/nestedLocalReference.json#/properties/result" }
+        }
+    },
+    "tests": [
+        {
+            "description": "nested reference, correct type",
+            "data": {"result": "some text" },
+            "valid": true
+        },
+        {
+            "description": "nested reference, incorrect type",
+            "data": {"result": 1234 },
+            "valid": false
+        }
+    ]
+}]""")
 
-        @testset "$tfn" for tfn in filter(n -> occursin(r"\.json$",n), readdir(tsdir))
-            fn = joinpath(tsdir, tfn)
-            schema = JSON.parsefile(fn)
-            @testset "- $(subschema["description"])" for subschema in (schema)
-                spec = subschema["schema"] isa Bool ?
-                    Schema(subschema["schema"]; idmap0=idmap0) :
-                    Schema(subschema["schema"]; idmap0=idmap0, parentFileDirectory = dirname(fn))
-
+@testset "Draft 4/6" begin
+    # Note(odow): I didn't want to use a mutable reference like this for the web-server.
+    # The obvious thing to do is to start a new server for each value of `draft_folder`,
+    # however, shutting down the webserver asynchronously doesn't play well with
+    # testsets, and I spent far too long trying to figure out what was going on.
+    # This is a simple hack until someone who knows more about this comes along...
+    GLOBAL_TEST_DIR = Ref{String}("")
+    server = HTTP.Sockets.listen(
+        HTTP.Sockets.InetAddr(parse(HTTP.Sockets.IPAddr, "127.0.0.1"), 1234)
+    )
+    @async HTTP.listen("127.0.0.1", 1234; server = server, verbose = true) do http
+        # Make sure to strip first character (`/`) from the target, otherwise it will
+        # infer as a file in the root directory.
+        file = joinpath(GLOBAL_TEST_DIR[], "../../remotes", http.message.target[2:end])
+        HTTP.setstatus(http, 200)
+        startwrite(http)
+        write(http, read(file, String))
+    end
+    @testset "$(draft_folder)" for draft_folder in [
+        "draft4", "draft6", basename(abspath(LOCAL_TEST_DIR))
+    ]
+        test_dir = joinpath(SCHEMA_TEST_DIR, draft_folder)
+        GLOBAL_TEST_DIR[] = test_dir
+        @testset "$tfn" for tfn in filter(n -> occursin(r"\.json$",n), readdir(test_dir))
+            fn = joinpath(test_dir, tfn)
+            @testset "- $(subschema["description"])" for subschema in (JSON.parsefile(fn))
+                dir = subschema["schema"] isa Bool ? abspath(".") : dirname(fn)
+                spec = Schema(subschema["schema"]; parentFileDirectory = dir)
                 @testset "* $(subtest["description"])" for subtest in subschema["tests"]
-                    result = isvalid(subtest["data"], spec) == subtest["valid"]
-                    @test result
-                    if !result
-                        @show subtest, spec.data
-                    end
+                    @test isvalid(subtest["data"], spec) == subtest["valid"]
                 end
             end
         end
     end
+    close(server)
 end
 
 @testset "Validate and diagnose" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -236,4 +236,40 @@ end
             "definitions": [1, 2]
         }""")
     )
+    @test_throws(
+        ErrorException("cannot support circular references in schema."),
+        validate(
+            Dict("version" => 1),
+            Schema("""{
+                "type": "object",
+                "properties": {
+                    "version": {
+                        "\$ref": "#/definitions/Foo"
+                    }
+                },
+                "definitions": {
+                    "Foo": {
+                        "\$ref": "#/definitions/Foo"
+                    }
+                }
+            }""")
+        )
+    )
+end
+
+@testset "_is_type" begin
+    for (key, val) in Dict(
+        :array => [1, 2],
+        :boolean => true,
+        :integer => 1,
+        :number => 1.0,
+        :null => nothing,
+        :object => Dict(),
+        :string => "string",
+    )
+        @test JSONSchema._is_type(val, Val(Symbol(key)))
+        @test !JSONSchema._is_type(:not_a_json_type, Val(Symbol(key)))
+    end
+    @test !JSONSchema._is_type(true, Val(:number))
+    @test !JSONSchema._is_type(true, Val(:integer))
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -140,7 +140,8 @@ write(
             @testset "$(schema["description"])" for schema in JSON.parsefile(file_path)
                 spec = Schema(
                     schema["schema"];
-                    dir = schema["schema"] isa Bool ? abspath(".") : dirname(file_path)
+                    parent_dir =
+                        schema["schema"] isa Bool ? abspath(".") : dirname(file_path)
                 )
                 @testset "$(test["description"])" for test in schema["tests"]
                     @test isvalid(test["data"], spec) == test["valid"]
@@ -173,6 +174,11 @@ end
     @test sprint(show, ret) == fail_msg
     @test diagnose(data_pass, schema) === nothing
     @test diagnose(data_fail, schema) == fail_msg
+end
+
+@testset "parentFileDirectory deprecation" begin
+    schema = Schema("{}"; parentFileDirectory = ".")
+    @test typeof(schema) == Schema
 end
 
 @testset "Schemas" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,18 +1,24 @@
-using BinaryProvider
 using HTTP
 using JSONSchema
 using JSON
 using Test
+using ZipFile
 
-const TEST_SUITE_URL = "https://github.com/json-schema-org/JSON-Schema-Test-Suite/archive/2.0.0.tar.gz"
+const TEST_SUITE_URL = "https://github.com/json-schema-org/JSON-Schema-Test-Suite/archive/2.0.0.zip"
 
 const SCHEMA_TEST_DIR = let
     dest_dir = mktempdir()
-    dest_file = joinpath(dest_dir, "test-suite.tar.gz")
-    BinaryProvider.download(TEST_SUITE_URL, dest_file, verbose = true)
-    unzip_dir = joinpath(dest_dir, "test-suite")
-    BinaryProvider.unpack(dest_file, unzip_dir)
-    joinpath(unzip_dir, "JSON-Schema-Test-Suite-2.0.0", "tests")
+    dest_file = joinpath(dest_dir, "test-suite.zip")
+    download(TEST_SUITE_URL, dest_file)
+    for f in ZipFile.Reader(dest_file).files
+        filename = joinpath(dest_dir, "test-suite", f.name)
+        if endswith(filename, "/")
+            mkpath(filename)
+        else
+            write(filename, read(f, String))
+        end
+    end
+    joinpath(dest_dir, "test-suite", "JSON-Schema-Test-Suite-2.0.0", "tests")
 end
 
 const LOCAL_TEST_DIR = mktempdir(SCHEMA_TEST_DIR)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -204,3 +204,44 @@ end
     @test typeof(schema_2) == Schema
     @test typeof(schema_2.data) == Bool
 end
+
+@testset "Base.show" begin
+    schema = Schema("{}")
+    @test sprint(show, schema) == "A JSONSchema"
+end
+
+@testset "errors" begin
+    @test_throws(
+        ErrorException("missing property 'Foo' in $(Dict{String,Any}())."),
+        Schema("""{
+            "type": "object",
+            "properties": {"version": {"\$ref": "#/definitions/Foo"}},
+            "definitions": {}
+        }""")
+    )
+
+    @test_throws(
+        ErrorException("unmanaged type in ref resolution $(Int): 1."),
+        Schema("""{
+            "type": "object",
+            "properties": {"version": {"\$ref": "#/definitions/Foo"}},
+            "definitions": 1
+        }""")
+    )
+    @test_throws(
+        ErrorException("expected integer array index instead of 'Foo'."),
+        Schema("""{
+            "type": "object",
+            "properties": {"version": {"\$ref": "#/definitions/Foo"}},
+            "definitions": [1, 2]
+        }""")
+    )
+    @test_throws(
+        ErrorException("item index 3 is larger than array $(Any[1, 2])."),
+        Schema("""{
+            "type": "object",
+            "properties": {"version": {"\$ref": "#/definitions/3"}},
+            "definitions": [1, 2]
+        }""")
+    )
+end


### PR DESCRIPTION
Slowly working my way through schema and runtests to educate myself about what this code does. The changes are mainly style and simplifications.

- Most important change is that we now start-up a local webserver in the tests, instead of passing some initial `idmap0` (which is now removed). @fredo-dedup as far as I can tell, `idmap0` was undocumented and only used by the tests to work-around the lack of a webserver?

- I renamed `parentFileDirectory` to `parent_dir` for a little more consistency.