### PR TITLE
add more robust checking of circular references

### DIFF
--- a/src/validation.jl
+++ b/src/validation.jl
@@ -80,7 +80,7 @@ function _resolve_refs(schema::Dict, explored_refs = Any[schema])
         return schema
     end
     schema = schema["\$ref"]
-    if schema in explored_refs
+    if any(x -> x === schema, explored_refs)
         error("cannot support circular references in schema.")
     end
     push!(explored_refs, schema)


### PR DESCRIPTION
The tests fail on 1.5 with a stack overflow error due
to a change how `==` is implemented on Dicts, leading
to a StackOverflowError for recursive dicts. This
change fixes it (and is arguably more correct)

Ref https://github.com/JuliaLang/julia/issues/36101