### PR TITLE
Bump version to v1.0.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "JSONSchema"
 uuid = "7d188eb4-7ad8-530c-ae41-71a32a6d4692"
-version = "0.3.4"
+version = "1.0.0"
 
 [deps]
 HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"


### PR DESCRIPTION
Unless we decide to include #26, I'd like to tag a 1.0 release of JSONSchema. (It's a dependency of MathOptInterface, which is approaching it's 1.0 release: https://github.com/jump-dev/MathOptInterface.jl/blob/3897b7cfb4f93335b1b367b609e0b50587a47bec/Project.toml#L23).

I'l leave this open for a few days for anyone to chime in.