### PR TITLE
Make files read with JSON3.jl compatible

### DIFF
--- a/JSONSchema/Project.toml
+++ b/JSONSchema/Project.toml
@@ -1,4 +1,5 @@
 [deps]
 HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
+JSON3 = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"
 OrderedCollections = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
 ZipFile = "a5390f91-8eb1-5f08-bee0-b1d1ffed6cea"

--- a/JSONSchema/Project.toml
+++ b/JSONSchema/Project.toml
@@ -1,5 +1,0 @@
-[deps]
-HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
-JSON3 = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"
-OrderedCollections = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
-ZipFile = "a5390f91-8eb1-5f08-bee0-b1d1ffed6cea"

--- a/JSONSchema/Project.toml
+++ b/JSONSchema/Project.toml
@@ -1,0 +1,4 @@
+[deps]
+HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
+OrderedCollections = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
+ZipFile = "a5390f91-8eb1-5f08-bee0-b1d1ffed6cea"

--- a/Project.toml
+++ b/Project.toml
@@ -5,8 +5,9 @@ version = "1.2.0"
 [deps]
 Downloads = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
-URIs = "5c2747f8-b7ea-4ff2-ba2e-563bfd36b1d4"
 JSON3 = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"
+TestEnv = "1e6cf692-eddd-4d53-88a5-2d735e33781b"
+URIs = "5c2747f8-b7ea-4ff2-ba2e-563bfd36b1d4"
 
 [compat]
 HTTP = "1"

--- a/Project.toml
+++ b/Project.toml
@@ -11,7 +11,7 @@ URIs = "5c2747f8-b7ea-4ff2-ba2e-563bfd36b1d4"
 [compat]
 HTTP = "1"
 JSON = "0.21"
-JSON3 = ""
+JSON3 = "1"
 OrderedCollections = "1"
 URIs = "1"
 ZipFile = "0.8, 0.9, 0.10"

--- a/Project.toml
+++ b/Project.toml
@@ -4,12 +4,9 @@ version = "1.2.0"
 
 [deps]
 Downloads = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
-HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
-JSON3 = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"
-OrderedCollections = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
 URIs = "5c2747f8-b7ea-4ff2-ba2e-563bfd36b1d4"
-ZipFile = "a5390f91-8eb1-5f08-bee0-b1d1ffed6cea"
+JSON3 = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"
 
 [compat]
 HTTP = "1"

--- a/Project.toml
+++ b/Project.toml
@@ -6,12 +6,12 @@ version = "1.2.0"
 Downloads = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 JSON3 = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"
-TestEnv = "1e6cf692-eddd-4d53-88a5-2d735e33781b"
 URIs = "5c2747f8-b7ea-4ff2-ba2e-563bfd36b1d4"
 
 [compat]
 HTTP = "1"
 JSON = "0.21"
+JSON3 = ""
 OrderedCollections = "1"
 URIs = "1"
 ZipFile = "0.8, 0.9, 0.10"

--- a/Project.toml
+++ b/Project.toml
@@ -4,8 +4,12 @@ version = "1.2.0"
 
 [deps]
 Downloads = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
+HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+JSON3 = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"
+OrderedCollections = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
 URIs = "5c2747f8-b7ea-4ff2-ba2e-563bfd36b1d4"
+ZipFile = "a5390f91-8eb1-5f08-bee0-b1d1ffed6cea"
 
 [compat]
 HTTP = "1"

--- a/src/JSONSchema.jl
+++ b/src/JSONSchema.jl
@@ -7,6 +7,7 @@ module JSONSchema
 
 import Downloads
 import JSON
+import JSON3
 import URIs
 
 export Schema, validate

--- a/src/schema.jl
+++ b/src/schema.jl
@@ -235,7 +235,6 @@ struct Schema
 
         # Keys need to be strings
         if schema isa JSON3.Object || schema isa JSON3.Array
-            schema = copy(schema)
 
             f_helper(x) = x
             f_helper(d::AbstractDict) = Dict{String,Any}(string(k) => f_helper(v) for (k, v) in d)

--- a/src/schema.jl
+++ b/src/schema.jl
@@ -241,18 +241,9 @@ struct Schema
             parent_dir = parentFileDirectory
         end
         schema = deepcopy(schema)  # Ensure we don't modify the user's data!
-
         id_map = build_id_map(schema)
         resolve_refs!(schema, URIs.URI(), id_map, parent_dir)
         return new(schema)
-    end
-
-    function Schema(
-        schema::JSON3.Object;
-        parent_dir::String = abspath("."),
-        parentFileDirectory = nothing,
-    )
-        return Schema(_to_base_julia(schema), parent_dir = parent_dir, parentFileDirectory = parentFileDirectory)
     end
 end
 
@@ -285,5 +276,9 @@ my_schema = Schema(
 ```
 """
 Schema(schema::String; kwargs...) = Schema(JSON.parse(schema); kwargs...)
+
+function Schema(schema::JSON3.Object; kwargs...)
+    return Schema(_to_base_julia(schema); kwargs...)
+end
 
 Base.show(io::IO, ::Schema) = print(io, "A JSONSchema")

--- a/src/schema.jl
+++ b/src/schema.jl
@@ -233,21 +233,18 @@ struct Schema
         end
         schema = deepcopy(schema)  # Ensure we don't modify the user's data!
 
-        # If the schema is a JSON3 object, it needs to be turned in to a mutable dict with copy
+        # Keys need to be strings
         if schema isa JSON3.Object || schema isa JSON3.Array
             schema = copy(schema)
-        end
 
-        # Keys need to be strings
-        if any(i -> i isa Symbol, keys(schema))
             f_helper(x) = x
             f_helper(d::AbstractDict) = Dict{String,Any}(string(k) => f_helper(v) for (k, v) in d)
             f_helper(l::AbstractArray) = f_helper.(l)
             string_dict(d::AbstractDict) = f_helper(d)
+            
             schema = string_dict(schema)
         end
-        
-       
+
         id_map = build_id_map(schema)
         resolve_refs!(schema, URIs.URI(), id_map, parent_dir)
         return new(schema)

--- a/src/schema.jl
+++ b/src/schema.jl
@@ -205,7 +205,7 @@ _to_base_julia(x) = x
 _to_base_julia(x::JSON3.Array) = _to_base_julia.(x)
 
 function _to_base_julia(x::JSON3.Object)
-    return Dict{String,Any}(string(k) => _to_base_julia(v) for (k,v) in x)
+    return Dict{String,Any}(string(k) => _to_base_julia(v) for (k, v) in x)
 end
 
 """

--- a/src/schema.jl
+++ b/src/schema.jl
@@ -202,7 +202,7 @@ end
 # Turning JSON3 read files in to base Julia dicts with string keys
 _to_base_julia(x) = x
 
-_to_base_julia(x::JSON.Array) = _to_base_julia.(x)
+_to_base_julia(x::JSON3.Array) = _to_base_julia.(x)
 
 function _to_base_julia(x::JSON3.Object)
     return Dict{String,Any}(string(k) => _to_base_julia(v) for (k,v) in x)

--- a/src/validation.jl
+++ b/src/validation.jl
@@ -66,19 +66,17 @@ schema value: ["foo"]
 ```
 """
 function validate(schema::Schema, x)
-    x = deepcopy(x)
-    # If the thing to validate is from JSON3.jl, need it to be a regular dictionary
+
+    # If thing to validate came from JSON3.jl, turn it in to a dictionary with string keys
     if x isa JSON3.Object || x isa JSON3.Array
         x = copy(x)
-    end
 
-    # Need the dictionary to have string keys
-    if any(i -> i isa Symbol, keys(x))
         #recursively makes a dictionary have string keys
-        f_helper(input) = input
+        f_helper(x) = x
         f_helper(d::AbstractDict) = Dict{String,Any}(string(k) => f_helper(v) for (k, v) in d)
-        f_helper(l::AbstractArray) = length(l) > 0 ? f_helper.(l) : l #for JSON arrays
+        f_helper(l::AbstractArray) =  f_helper.(l) #for JSON arrays
         string_dict(d::AbstractDict) = f_helper(d)
+
         x = string_dict(x)
     end
 

--- a/src/validation.jl
+++ b/src/validation.jl
@@ -66,6 +66,22 @@ schema value: ["foo"]
 ```
 """
 function validate(schema::Schema, x)
+    x = deepcopy(x)
+    # If the thing to validate is from JSON3.jl, need it to be a regular dictionary
+    if x isa JSON3.Object || x isa JSON3.Array
+        x = copy(x)
+    end
+
+    # Need the dictionary to have string keys
+    if any(i -> i isa Symbol, keys(x))
+        #recursively makes a dictionary have string keys
+        f_helper(input) = input
+        f_helper(d::AbstractDict) = Dict{String,Any}(string(k) => f_helper(v) for (k, v) in d)
+        f_helper(l::AbstractArray) = length(l) > 0 ? f_helper.(l) : l #for JSON arrays
+        string_dict(d::AbstractDict) = f_helper(d)
+        x = string_dict(x)
+    end
+
     return _validate(x, schema.data, "")
 end
 

--- a/src/validation.jl
+++ b/src/validation.jl
@@ -69,7 +69,7 @@ function validate(schema::Schema, x)
     return _validate(x, schema.data, "")
 end
 
-function validate(schema::Schema, x::Union{JSON3.Object, JSON3.Array})
+function validate(schema::Schema, x::Union{JSON3.Object,JSON3.Array})
     return validate(schema, _to_base_julia(x))
 end
 

--- a/src/validation.jl
+++ b/src/validation.jl
@@ -66,20 +66,11 @@ schema value: ["foo"]
 ```
 """
 function validate(schema::Schema, x)
-
-    # If thing to validate came from JSON3.jl, turn it in to a dictionary with string keys
-    if x isa JSON3.Object || x isa JSON3.Array
-        
-        #recursively makes a dictionary have string keys
-        f_helper(x) = x
-        f_helper(d::AbstractDict) = Dict{String,Any}(string(k) => f_helper(v) for (k, v) in d)
-        f_helper(l::AbstractArray) =  f_helper.(l) #for JSON arrays
-        string_dict(d::AbstractDict) = f_helper(d)
-
-        x = string_dict(x)
-    end
-
     return _validate(x, schema.data, "")
+end
+
+function validate(schema::Schema, x::Union{JSON3.Object, JSON3.Array})
+    return validate(schema, _to_base_julia(x))
 end
 
 Base.isvalid(schema::Schema, x) = validate(schema, x) === nothing

--- a/src/validation.jl
+++ b/src/validation.jl
@@ -69,8 +69,7 @@ function validate(schema::Schema, x)
 
     # If thing to validate came from JSON3.jl, turn it in to a dictionary with string keys
     if x isa JSON3.Object || x isa JSON3.Array
-        x = copy(x)
-
+        
         #recursively makes a dictionary have string keys
         f_helper(x) = x
         f_helper(d::AbstractDict) = Dict{String,Any}(string(k) => f_helper(v) for (k, v) in d)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,9 +6,9 @@
 using JSONSchema
 using Test
 import Downloads
-import JSON3
 import HTTP
 import JSON
+import JSON3
 import OrderedCollections
 import ZipFile
 
@@ -214,6 +214,7 @@ end
     end
     close(server)
 end
+
 @testset "Validate and diagnose" begin
     schema = JSONSchema.Schema(
         Dict(

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -214,7 +214,6 @@ end
     end
     close(server)
 end
-
 @testset "Validate and diagnose" begin
     schema = JSONSchema.Schema(
         Dict(

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -202,21 +202,18 @@ end
             @testset "$(schema["description"])" for schema in
                                                     JSON3.read(file_path)
                 spec = JSONSchema.Schema(
-                    schema["schema"];
-                    parent_dir = schema["schema"] isa Bool ? abspath(".") :
+                    schema[:schema];
+                    parent_dir = schema[:schema] isa Bool ? abspath(".") :
                                  dirname(file_path),
                 )
-                @testset "$(test["description"])" for test in schema["tests"]
-                    @test isnothing(validate(spec, test["data"])) == test["valid"]
+                @testset "$(test["description"])" for test in schema[:tests]
+                    @test isnothing(validate(spec, test[:data])) == test[:valid]
                 end
             end
         end
     end
     close(server)
 end
-
-
-
 
 @testset "Validate and diagnose" begin
     schema = JSONSchema.Schema(
@@ -245,7 +242,6 @@ end
     schema = JSONSchema.Schema("{}"; parentFileDirectory = ".")
     @test typeof(schema) == Schema
 end
-
 
 @testset "Schemas" begin
     schema = JSONSchema.Schema("""{

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -173,6 +173,50 @@ write(
     close(server)
 end
 
+@testset "Draft 4/6 JSON3 parsing" begin
+    # Note(odow): I didn't want to use a mutable reference like this for the web-server.
+    # The obvious thing to do is to start a new server for each value of `draft_folder`,
+    # however, shutting down the webserver asynchronously doesn't play well with
+    # testsets, and I spent far too long trying to figure out what was going on.
+    # This is a simple hack until someone who knows more about this comes along...
+    GLOBAL_TEST_DIR = Ref{String}("")
+    server = HTTP.Sockets.listen(HTTP.ip"127.0.0.1", 1234)
+    HTTP.serve!("127.0.0.1", 1234; server = server) do req
+        # Make sure to strip first character (`/`) from the target, otherwise it
+        # will infer as a file in the root directory.
+        file = joinpath(GLOBAL_TEST_DIR[], "../../remotes", req.target[2:end])
+        return HTTP.Response(200, read(file, String))
+    end
+    @testset "$(draft_folder)" for draft_folder in [
+        "draft4",
+        "draft6",
+        basename(abspath(LOCAL_TEST_DIR)),
+    ]
+        test_dir = joinpath(SCHEMA_TEST_DIR, draft_folder)
+        GLOBAL_TEST_DIR[] = test_dir
+        @testset "$(file)" for file in filter(
+            n -> endswith(n, ".json"),
+            readdir(test_dir),
+        )
+            file_path = joinpath(test_dir, file)
+            @testset "$(schema["description"])" for schema in
+                                                    JSON3.read(file_path)
+                spec = JSONSchema.Schema(
+                    schema["schema"];
+                    parent_dir = schema["schema"] isa Bool ? abspath(".") :
+                                 dirname(file_path),
+                )
+                @testset "$(test["description"])" for test in schema["tests"]
+                    @test isnothing(validate(spec, test["data"])) == test["valid"]
+                end
+            end
+        end
+    end
+    close(server)
+end
+
+
+
 
 @testset "Validate and diagnose" begin
     schema = JSONSchema.Schema(

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,6 +6,7 @@
 using JSONSchema
 using Test
 import Downloads
+import JSON3
 import HTTP
 import JSON
 import OrderedCollections
@@ -172,6 +173,50 @@ write(
     close(server)
 end
 
+JSON3Tests = @testset "Draft 4/6 JSON3" begin
+    # Note(odow): I didn't want to use a mutable reference like this for the web-server.
+    # The obvious thing to do is to start a new server for each value of `draft_folder`,
+    # however, shutting down the webserver asynchronously doesn't play well with
+    # testsets, and I spent far too long trying to figure out what was going on.
+    # This is a simple hack until someone who knows more about this comes along...
+
+    GLOBAL_TEST_DIR = Ref{String}("")
+    server = HTTP.Sockets.listen(HTTP.ip"127.0.0.1", 1234)
+    HTTP.serve!("127.0.0.1", 1234; server = server) do req
+        # Make sure to strip first character (`/`) from the target, otherwise it
+        # will infer as a file in the root directory.
+        file = joinpath(GLOBAL_TEST_DIR[], "../../remotes", req.target[2:end])
+        return HTTP.Response(200, read(file, String))
+    end
+    @testset "$(draft_folder)" for draft_folder in [
+        "draft4",
+        "draft6",
+        basename(abspath(LOCAL_TEST_DIR)),
+    ]
+        test_dir = joinpath(SCHEMA_TEST_DIR, draft_folder)
+        GLOBAL_TEST_DIR[] = test_dir
+        @testset "$(file)" for file in filter(
+            n -> endswith(n, ".json"),
+            readdir(test_dir),
+        )
+            file_path = joinpath(test_dir, file)
+            @testset "$(schema["description"])" for schema in
+                                                    JSON3.read(file_path)
+                schema = copy(schema)
+                spec = JSONSchema.Schema(
+                    schema["schema"];
+                    parent_dir = schema["schema"] isa Bool ? abspath(".") :
+                                 dirname(file_path),
+                )
+                @testset "$(test["description"])" for test in schema["tests"]
+                    @test isvalid(spec, test["data"]) == test["valid"]
+                end
+            end
+        end
+    end
+    close(server)
+end
+
 @testset "Validate and diagnose" begin
     schema = JSONSchema.Schema(
         Dict(
@@ -198,6 +243,29 @@ end
 @testset "parentFileDirectory deprecation" begin
     schema = JSONSchema.Schema("{}"; parentFileDirectory = ".")
     @test typeof(schema) == Schema
+end
+
+@testset "Validate and diagnose symbol keys" begin
+    schema = JSONSchema.Schema(
+        Dict(
+            :properties => Dict(:foo => Dict(), :bar => Dict()),
+            :required => ["foo"],
+        ),
+    )
+    data_pass = Dict(:foo => true)
+    data_fail = Dict(:bar => 12.5)
+    @test JSONSchema.validate(schema, data_pass) === nothing
+    ret = JSONSchema.validate(schema, data_fail)
+    fail_msg = """Validation failed:
+    path:         top-level
+    instance:     $(data_fail)
+    schema key:   required
+    schema value: ["foo"]
+    """
+    @test ret !== nothing
+    @test sprint(show, ret) == fail_msg
+    @test JSONSchema.diagnose(data_pass, schema) === nothing
+    @test JSONSchema.diagnose(data_fail, schema) == fail_msg
 end
 
 @testset "Schemas" begin


### PR DESCRIPTION
I was trying to validate a file that was parsed using JSON3.jl, with a schema parsed  using JSON3.jl, and ran in to some problems. 

The first was that the references in the schema were not being resolved. Because the JSON3.jl objects and arrays are not mutable, the way references are resolved did not work. 

Second, the use of haskey in the creation of the schema object / reference resolution and validation means that the keys must be strings. JSON3 tends to use Symbols for its keys. 

Essentially, I just made it so that if the schema to turn in to a Schema object was from JSON3, recursively turn it in to a mutable dictionary with keys that are strings. Same thing for the JSON file to validate, if it's from JSON3, turn it in to a dictionary with string keys. 