### PR TITLE
Fixes and improvements for the 23.1.0 test schema

### DIFF
--- a/src/schema.jl
+++ b/src/schema.jl
@@ -123,7 +123,7 @@ function find_ref(
                 JSON.parsefile(uri2.path);
                 parent_dir = dirname(uri2.path),
             )
-            id_map[string(uri2)] = schema.data
+            id_map[string(uri2)] = local_schema.data
         end
     end
     return get_element(id_map[string(uri2)], uri.fragment)

--- a/src/schema.jl
+++ b/src/schema.jl
@@ -36,7 +36,11 @@ function update_id(uri::URIs.URI, s::String)
 end
 
 function get_element(schema, path::AbstractString)
-    for element in split(path, "/"; keepempty = false)
+    elements = split(path, "/"; keepempty = true)
+    if isempty(first(elements))
+        popfirst!(elements)
+    end
+    for element in elements
         schema = _recurse_get_element(schema, unescape_jpath(String(element)))
     end
     return schema

--- a/src/validation.jl
+++ b/src/validation.jl
@@ -531,7 +531,8 @@ function _validate(
     val::Number,
     path::String,
 )
-    if !isapprox(x / val, round(x / val))
+    y = x / val
+    if !isfinite(y) || !isapprox(y, round(y))
         return SingleIssue(x, path, "multipleOf", val)
     end
     return


### PR DESCRIPTION
Part of #37 

I'm working through issues locally with
```diff
diff --git a/test/runtests.jl b/test/runtests.jl
index aa65798..45513d0 100644
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,7 +12,7 @@ import JSON3
 import OrderedCollections
 import ZipFile
 
-const TEST_SUITE_URL = "https://github.com/json-schema-org/JSON-Schema-Test-Suite/archive/2.0.0.zip"
+const TEST_SUITE_URL = "https://github.com/json-schema-org/JSON-Schema-Test-Suite/archive/23.1.0.zip"
 
 const SCHEMA_TEST_DIR = let
     dest_dir = mktempdir()
@@ -26,7 +26,7 @@ const SCHEMA_TEST_DIR = let
             write(filename, read(f, String))
         end
     end
-    joinpath(dest_dir, "test-suite", "JSON-Schema-Test-Suite-2.0.0", "tests")
+    joinpath(dest_dir, "test-suite", "JSON-Schema-Test-Suite-23.1.0", "tests")
 end
 
 const LOCAL_TEST_DIR = mktempdir(SCHEMA_TEST_DIR)
```

I'm currently at:
```
Some tests did not pass: 2209 passed, 13 failed, 17 errored, 0 broken.
```